### PR TITLE
Add a new option to collect details about subtest failures for inclusion in HTML report

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ Options:
   --pause <case>           Pause execution on failure
   --browser-path <path>    Custom path to browser executable
   --skip-retry             Skip the retry stage for failed tests
+  --verbose                Capture detailed per-subtest failure information
 
 Test Selection:
   --wpt-case <filter>      Run specific WPT test cases
@@ -103,6 +104,7 @@ Examples:
   const configFile = getArg('--config');
   const pauseCase = getArg('--pause');
   const wptRange = getArg('--wpt-range');
+  const verbose = args.includes('--verbose');
 
   // --- Config Generation ---
   let runConfigs = [];
@@ -178,6 +180,7 @@ Examples:
   }
   if (browserPath) process.env.BROWSER_PATH = browserPath;
   if (skipRetry) process.env.SKIP_RETRY = 'true';
+  if (verbose) process.env.VERBOSE = 'true';
 
   delete process.env.TEST_SUITE;
   delete process.env.DEVICE;

--- a/src/util.js
+++ b/src/util.js
@@ -921,6 +921,22 @@ class WebNNRunner {
                       const statusStyle = `color: ${statusColor}; font-weight: bold;`;
                       const baseTdStyle = "border: 1px solid #e1e4e8; padding: 8px 12px; text-align: left;";
 
+                      // Generate failed subtests HTML if available
+                      const failedSubtestsHtml = result.failedSubtests && result.failedSubtests.length > 0 ? `
+                                <br><details style="margin-top: 5px;">
+                                    <summary style="cursor: pointer; color: #dc3545; font-size: 12px; font-weight: bold;">View Failed Subtests (${result.failedSubtests.length})</summary>
+                                    <div style="margin-top: 5px; padding: 10px; background-color: #fff5f5; border-radius: 4px; border: 1px solid #f5c6cb; max-height: 400px; overflow-y: auto;">
+                                        ${result.failedSubtests.map((subtest, idx) => `
+                                            <div style="margin: 8px 0; padding: 8px; background-color: #fff; border-left: 3px solid #dc3545; border-radius: 2px;">
+                                                <div style="font-size: 12px; font-weight: bold; color: #24292e; word-break: break-word;">${idx + 1}. ${subtest.name}</div>
+                                                ${subtest.status && subtest.status !== 'FAIL' ? `<div style="font-size: 11px; color: #fd7e14; margin-top: 2px;">Status: ${subtest.status}</div>` : ''}
+                                                ${subtest.message ? `<div style="font-size: 11px; color: #586069; margin-top: 4px; font-family: monospace; white-space: pre-wrap; word-break: break-word; background-color: #f6f8fa; padding: 4px; border-radius: 2px;">${subtest.message}</div>` : ''}
+                                            </div>
+                                        `).join('')}
+                                    </div>
+                                </details>
+                                ` : '';
+
                       return `
                         <tr>
                             <td style="${baseTdStyle}"><strong>${(result.device || 'N/A').toUpperCase()}</strong></td>
@@ -930,6 +946,7 @@ class WebNNRunner {
                                 ${result.testUrl ? `<br><small><a href="${result.testUrl}" target="_blank" style="color: #0366d6;">${result.testUrl}</a></small>` : ''}
                                 ${result.details && !result.details.includes('Exception') ? `<br><div style="margin-top:4px; font-size: 0.9em; color: #24292e; background-color: #e6ffed; padding: 5px; border-left: 3px solid #28a745; border-radius: 2px;">${result.details}</div>` : ''}
                                 ${result.fullText && result.hasErrors ? `<br><div style="margin-top:4px; font-size: 0.9em; color: #a00; background-color: #fff0f0; padding: 5px; border-left: 3px solid #a00; border-radius: 2px;">${result.fullText}</div>` : ''}
+                                ${failedSubtestsHtml}
                                 ${result.retryHistory && result.retryHistory.length > 1 ? `
                                 <br><details style="margin-top: 5px;">
                                     <summary style="cursor: pointer; color: #0366d6; font-size: 12px;">View Retry History (${retryCount} attempts)</summary>

--- a/src/wpt.js
+++ b/src/wpt.js
@@ -341,7 +341,10 @@ class WptRunner extends WebNNRunner {
         await page.waitForTimeout(2000);
 
         // Parse results with robust logic from original file
-        const resData = await page.evaluate(() => {
+        // Also scrape detailed failure info if verbose mode is enabled
+        const verboseEnabled = process.env.VERBOSE === 'true';
+        
+        const resData = await page.evaluate((scrapeDetails) => {
             const body = document.body.textContent;
             let subcases = { total: 0, passed: 0, failed: 0 };
 
@@ -409,8 +412,125 @@ class WptRunner extends WebNNRunner {
             else if (body.includes('PASS')) { subcases.total=1; subcases.passed=1; resultStatus = 'PASS'; }
             else if (body.includes('FAIL')) { subcases.total=1; subcases.failed=1; resultStatus = 'FAIL'; }
 
-            return { result: resultStatus, subcases };
-        });
+            // Scrape detailed failure info if requested and there are failures
+            let failedSubtests = [];
+            if (scrapeDetails && subcases.failed > 0) {
+                // WPT results structure: #results IS the table element (contains thead/tbody directly)
+                // Don't use '#results table' as that matches nested empty tables in <details>
+                const resultsTable = document.querySelector('#results');
+                
+                if (resultsTable) {
+                    // Query direct child rows from tbody using :scope
+                    const tbody = resultsTable.querySelector('tbody');
+                    const allRows = tbody ? tbody.querySelectorAll(':scope > tr') : resultsTable.querySelectorAll(':scope > tr');
+                    
+                    allRows.forEach(row => {
+                        // Skip header rows
+                        if (row.querySelector('th')) return;
+                        
+                        const cells = row.querySelectorAll('td');
+                        if (cells.length >= 2) {
+                            const statusCell = cells[0];
+                            const nameCell = cells[1];
+                            const messageCell = cells[2];
+                            
+                            const status = statusCell ? statusCell.textContent.trim().toUpperCase() : '';
+                            
+                            if (status === 'FAIL' || status === 'TIMEOUT' || status === 'ERROR' || status === 'NOTRUN') {
+                                // Test name is in the second column
+                                const testName = nameCell ? nameCell.textContent.trim().split('\n')[0].substring(0, 300) : 'Unknown';
+                                
+                                // Message is in the third column
+                                let message = '';
+                                if (messageCell) {
+                                    const clone = messageCell.cloneNode(true);
+                                    const details = clone.querySelector('details');
+                                    if (details) details.remove();
+                                    message = clone.textContent.trim().substring(0, 800);
+                                }
+                                
+                                failedSubtests.push({
+                                    name: testName || 'Unknown subtest',
+                                    status: status,
+                                    message: message
+                                });
+                            }
+                        }
+                    });
+                }
+            }
+
+            return { result: resultStatus, subcases, failedSubtests };
+        }, verboseEnabled);
+
+        // If verbose mode is enabled and there are failures but no details captured, try scraping separately
+        let failedSubtests = resData.failedSubtests || [];
+        if (verboseEnabled && resData.subcases.failed > 0 && failedSubtests.length === 0) {
+            // Wait a bit more for the table to populate
+            await page.waitForTimeout(1000);
+            
+            try {
+                failedSubtests = await page.evaluate(() => {
+                    const failures = [];
+                    
+                    // #results IS the table element (contains thead/tbody directly)
+                    // Don't look for a nested table - that matches the empty table in <details>
+                    const resultsTable = document.querySelector('#results');
+                    
+                    if (resultsTable) {
+                        // Query rows from tbody using :scope to get direct children only
+                        const tbody = resultsTable.querySelector('tbody');
+                        const allRows = tbody ? tbody.querySelectorAll(':scope > tr') : resultsTable.querySelectorAll(':scope > tr');
+                        
+                        allRows.forEach((row) => {
+                            // Skip header rows
+                            if (row.querySelector('th')) return;
+                            
+                            const cells = row.querySelectorAll('td');
+                            debug[`row${idx}CellCount`] = cells.length;
+                            
+                            if (cells.length >= 2) {
+                                const statusCell = cells[0];
+                                const nameCell = cells[1];
+                                const messageCell = cells[2];
+                                
+                                const status = statusCell ? statusCell.textContent.trim().toUpperCase() : '';
+                                debug[`row${idx}Status`] = status;
+                                
+                                if (status === 'FAIL' || status === 'TIMEOUT' || status === 'ERROR' || status === 'NOTRUN') {
+                                    // Test name is in the second column
+                                    const testName = nameCell ? nameCell.textContent.trim().split('\n')[0].substring(0, 300) : 'Unknown';
+                                    
+                                    // Message is in the third column, often starts with assertion text
+                                    let message = '';
+                                    if (messageCell) {
+                                        // Get text before <details> and clean it up
+                                        const clone = messageCell.cloneNode(true);
+                                        const details = clone.querySelector('details');
+                                        if (details) details.remove();
+                                        message = clone.textContent.trim().substring(0, 800);
+                                    }
+                                    
+                                    failures.push({
+                                        name: testName,
+                                        status: status,
+                                        message: message
+                                    });
+                                }
+                            }
+                        });
+                    }
+                    return failures;
+                });
+            } catch (e) {
+                // Scraping failed, continue without details
+            }
+        }
+
+        // Log captured failures
+        if (failedSubtests && failedSubtests.length > 0) {
+            console.log(`[${testName}] Captured ${failedSubtests.length} failed subtest(s) details`);
+        }
 
         console.log(`[${testName}] ${resData.result}: ${resData.subcases.passed} PASS, ${resData.subcases.failed} FAIL`);
 
@@ -420,6 +540,7 @@ class WptRunner extends WebNNRunner {
             suite: 'WPT',
             result: resData.result,
             subcases: resData.subcases,
+            failedSubtests: failedSubtests && failedSubtests.length > 0 ? failedSubtests : undefined,
             executionTime: '0.00'
         };
     };

--- a/src/wpt.js
+++ b/src/wpt.js
@@ -487,7 +487,6 @@ class WptRunner extends WebNNRunner {
                             if (row.querySelector('th')) return;
                             
                             const cells = row.querySelectorAll('td');
-                            debug[`row${idx}CellCount`] = cells.length;
                             
                             if (cells.length >= 2) {
                                 const statusCell = cells[0];
@@ -495,7 +494,6 @@ class WptRunner extends WebNNRunner {
                                 const messageCell = cells[2];
                                 
                                 const status = statusCell ? statusCell.textContent.trim().toUpperCase() : '';
-                                debug[`row${idx}Status`] = status;
                                 
                                 if (status === 'FAIL' || status === 'TIMEOUT' || status === 'ERROR' || status === 'NOTRUN') {
                                     // Test name is in the second column


### PR DESCRIPTION
## Why is this change being made?
WPT test reports show aggregate pass/fail counts without details about which specific subtests failed or their error messages. This feature adds an option for collecting this data and embedding it into the HTML report. 

Example UX:

<img width="2334" height="840" alt="image" src="https://github.com/user-attachments/assets/8719e26c-b4a9-4d65-9067-61b1424c97e6" />


## What changed?
Added `--verbose` flag that captures failed subtest details (test name, status, error message) from WPT result pages and embeds them in the HTML report as a collapsible "View Failed Subtests" section.

- `main.js`: Added `--verbose` flag parsing and help text
- `wpt.js`: Added scraping logic to extract failed subtests from the WPT results table
- `util.js`: Added HTML rendering for failed subtests in `generateHtmlReport`

## How was the change tested?
Ran `node src/main.js --suite wpt --verbose...` and verified:
1. Console output shows "Captured X failed subtest(s) details" messages
2. Generated HTML report contains "View Failed Subtests (N)" sections with individual test names and error messages